### PR TITLE
Support plugins for metrics via interfaces

### DIFF
--- a/internal/metrics/collector.go
+++ b/internal/metrics/collector.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"fmt"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -9,7 +10,8 @@ func Collect(pods []corev1.Pod) (*MetricSet, PhaseSet) {
 	metrics := NewMetricSet()
 	phaseSet := make(PhaseSet)
 	for _, pod := range pods {
-		metrics.Increment(findOwnerKind(pod), pod.ObjectMeta.Namespace, pod.Status.Phase)
+		kind := findOwnerKind(pod)
+		metrics.IncrementSelect(kind, pod.ObjectMeta.Namespace, fmt.Sprintf("%s-%s-%s", kind, pod.Namespace, pod.Status.Phase), map[string]string{dimensionPhase: fmt.Sprint(pod.Status.Phase)})
 		phaseSet[string(pod.Status.Phase)]++
 	}
 	return metrics, phaseSet

--- a/internal/metrics/collector_test.go
+++ b/internal/metrics/collector_test.go
@@ -30,7 +30,6 @@ func TestMetricsCollector_CollectMetrics(t *testing.T) {
 	}
 
 	metrics, phaseSet := Collect(pods)
-
 	assert.Equal(t, 3, metrics.Items["abc-def-Pending"].Value)
 	assert.Equal(t, 1, metrics.Items["abc-def-Succeeded"].Value)
 	assert.Equal(t, 1, metrics.Items["xyz-def-Succeeded"].Value)

--- a/internal/metrics/logger_test.go
+++ b/internal/metrics/logger_test.go
@@ -6,19 +6,18 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	corev1 "k8s.io/api/core/v1"
 )
 
 func TestLog(t *testing.T) {
 	metrics := NewMetricSet()
-	metrics.Increment("ReplicaSet", "foo", corev1.PodPending)
-	metrics.Increment("ReplicaSet", "foo", corev1.PodPending)
-	metrics.Increment("ReplicaSet", "foo", corev1.PodRunning)
-	metrics.Increment("ReplicaSet", "bar", corev1.PodPending)
-	metrics.Increment("ReplicaSet", "bar", corev1.PodRunning)
-	metrics.Increment("ReplicaSet", "bar", corev1.PodRunning)
-	metrics.Increment("ReplicaSet", "bar", corev1.PodRunning)
-	metrics.Increment("ReplicaSet", "bar", corev1.PodRunning)
+	metrics.IncrementSelect("ReplicaSet", "foo", "replicaset-foo-pending", map[string]string{dimensionPhase: "Pending"})
+	metrics.IncrementSelect("ReplicaSet", "foo", "replicaset-foo-pending", map[string]string{dimensionPhase: "Pending"})
+	metrics.IncrementSelect("ReplicaSet", "foo", "replicaset-foo-running", map[string]string{dimensionPhase: "Running"})
+	metrics.IncrementSelect("ReplicaSet", "bar", "replicaset-bar-pending", map[string]string{dimensionPhase: "Pending"})
+	metrics.IncrementSelect("ReplicaSet", "bar", "replicaset-bar-running", map[string]string{dimensionPhase: "Running"})
+	metrics.IncrementSelect("ReplicaSet", "bar", "replicaset-bar-running", map[string]string{dimensionPhase: "Running"})
+	metrics.IncrementSelect("ReplicaSet", "bar", "replicaset-bar-running", map[string]string{dimensionPhase: "Running"})
+	metrics.IncrementSelect("ReplicaSet", "bar", "replicaset-bar-running", map[string]string{dimensionPhase: "Running"})
 
 	var buf bytes.Buffer
 	err := Log(&buf, metrics)

--- a/internal/metrics/metric.go
+++ b/internal/metrics/metric.go
@@ -1,11 +1,5 @@
 package metrics
 
-import (
-	"fmt"
-
-	corev1 "k8s.io/api/core/v1"
-)
-
 // PhaseSet is the phase set.
 type PhaseSet map[string]int
 
@@ -29,20 +23,21 @@ type Metric struct {
 	Labels map[string]string `json:"labels"`
 }
 
-// Increment the metric.
-func (s *MetricSet) Increment(kind, namespace string, phase corev1.PodPhase) {
-	key := fmt.Sprintf("%s-%s-%s", kind, namespace, phase)
-	if metric, found := s.Items[key]; found {
+// IncrementSelect will selectively increment the metric based upon uuid input.
+func (s *MetricSet) IncrementSelect(kind, namespace string, uuid string, fields map[string]string) {
+	if metric, found := s.Items[uuid]; found {
 		metric.Value++
 	} else {
 		metric := &Metric{
 			Labels: map[string]string{
 				dimensionKind:      kind,
 				dimensionNamespace: namespace,
-				dimensionPhase:     string(phase),
 			},
 			Value: 1,
 		}
-		s.Items[key] = metric
+		for i, field := range fields {
+			metric.Labels[i] = field
+		}
+		s.Items[uuid] = metric
 	}
 }

--- a/internal/metrics/plugins/plugin.go
+++ b/internal/metrics/plugins/plugin.go
@@ -1,0 +1,22 @@
+package plugins
+
+import (
+	"context"
+	"io"
+	"k8s.io/client-go/kubernetes"
+	"time"
+
+	awstypes "github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+	"github.com/skpr/cluster-metrics/internal/metrics"
+)
+
+// ClusterMetricsPluginInterface defines an interface for cluster metrics to
+// plug into. Given a plugin could include extremely specific to the given
+// plugin, the signatures are as generic as possible and the functionality
+// as high-level as possible.
+type ClusterMetricsPluginInterface interface {
+	Collect(*kubernetes.Clientset) (*metrics.MetricSet, metrics.PhaseSet)
+	Convert(time.Time, string, map[string]interface{}) []awstypes.MetricDatum
+	Log(io.Writer, *metrics.MetricSet) error
+	Push(context.Context, *string, []awstypes.MetricDatum)
+}

--- a/internal/metrics/plugins/podsbyPhase/collect.go
+++ b/internal/metrics/plugins/podsbyPhase/collect.go
@@ -1,0 +1,29 @@
+package podsbyPhase
+
+import (
+	"context"
+	"fmt"
+
+	metricsS "github.com/skpr/cluster-metrics/internal/metrics"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func (c Client) Collect(clientset *kubernetes.Clientset) (*metricsS.MetricSet, metricsS.PhaseSet) {
+	podList, err := clientset.CoreV1().Pods(corev1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		panic("could not list pods in all namespaces:" + err.Error())
+	}
+	metrics := metricsS.NewMetricSet()
+	phaseSet := make(metricsS.PhaseSet)
+	for _, pod := range podList.Items {
+		for _, ref := range pod.ObjectMeta.OwnerReferences {
+			if ref.Kind != "" {
+				metrics.IncrementSelect(ref.Kind, pod.ObjectMeta.Namespace, fmt.Sprintf("%s-%s-%s", ref.Kind, dimensionNamespace, pod.Status.Phase), map[string]string{dimensionPhase: fmt.Sprint(pod.Status.Phase)})
+				phaseSet[string(pod.Status.Phase)]++
+			}
+		}
+	}
+	return metrics, phaseSet
+}

--- a/internal/metrics/plugins/podsbyPhase/collect_test.go
+++ b/internal/metrics/plugins/podsbyPhase/collect_test.go
@@ -1,0 +1,50 @@
+package podsbyPhase
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+func TestClient_Collect(t *testing.T) {
+	values := []map[string]string{
+		{"kind": "abc", "namespace": "def", "phase": string(corev1.PodPending)},
+		{"kind": "abc", "namespace": "def", "phase": string(corev1.PodPending)},
+		{"kind": "abc", "namespace": "def", "phase": string(corev1.PodPending)},
+		{"kind": "abc", "namespace": "def", "phase": string(corev1.PodSucceeded)},
+		{"kind": "xyz", "namespace": "def", "phase": string(corev1.PodSucceeded)},
+		{"kind": "abc", "namespace": "def", "phase": string(corev1.PodFailed)},
+		{"kind": "abc", "namespace": "def", "phase": string(corev1.PodFailed)},
+		{"kind": "abc", "namespace": "ghj", "phase": string(corev1.PodRunning)},
+		{"kind": "abc", "namespace": "ghj", "phase": string(corev1.PodRunning)},
+		{"kind": "xyz", "namespace": "ghj", "phase": string(corev1.PodRunning)},
+	}
+
+	var pods []corev1.Pod
+	for _, val := range values {
+		pods = append(pods, corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: val["namespace"],
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						Kind: val["kind"],
+					},
+				},
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodPhase(val["phase"]),
+			},
+		})
+	}
+
+	// TODO Collect() no longer takes input so need to work around this...
+	//metrics, phaseSet := client.Collect(pods)
+	//assert.Equal(t, 3, metrics.Items["abc-def-Pending"].Value)
+	//assert.Equal(t, 1, metrics.Items["abc-def-Succeeded"].Value)
+	//assert.Equal(t, 1, metrics.Items["xyz-def-Succeeded"].Value)
+	//assert.Equal(t, 2, metrics.Items["abc-def-Failed"].Value)
+	//assert.Equal(t, 2, metrics.Items["abc-ghj-Running"].Value)
+	//assert.Equal(t, 1, metrics.Items["xyz-ghj-Running"].Value)
+	//
+	//assert.Equal(t, 3, phaseSet["Running"])
+}

--- a/internal/metrics/plugins/podsbyPhase/convert.go
+++ b/internal/metrics/plugins/podsbyPhase/convert.go
@@ -1,0 +1,42 @@
+package podsbyPhase
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+	"sort"
+	"time"
+)
+
+func (c Client) Convert(timestamp time.Time, cluster string, labels map[string]interface{}) []awstypes.MetricDatum {
+	// Sort keys for a consistent result order.
+	keys := make([]string, 0, len(labels))
+	for k := range labels {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var data []awstypes.MetricDatum
+	for _, label := range labels {
+		value := labels[label.(string)]
+		datum := awstypes.MetricDatum{
+			MetricName: aws.String(metricTotal),
+			Dimensions: []awstypes.Dimension{
+				{
+					Name:  aws.String(dimensionCluster),
+					Value: aws.String(cluster),
+				},
+			},
+			Timestamp: aws.Time(timestamp),
+			Value:     aws.Float64(value.(float64)),
+		}
+		for i, value := range labels {
+			datum.Dimensions = append(datum.Dimensions, awstypes.Dimension{
+				Name:  aws.String(i),
+				Value: aws.String(fmt.Sprintf("%v", value)),
+			})
+		}
+		data = append(data, datum)
+	}
+	return data
+}

--- a/internal/metrics/plugins/podsbyPhase/covert_test.go
+++ b/internal/metrics/plugins/podsbyPhase/covert_test.go
@@ -1,0 +1,7 @@
+package podsbyPhase
+
+import "testing"
+
+func TestClient_Convert(t *testing.T) {
+
+}

--- a/internal/metrics/plugins/podsbyPhase/log.go
+++ b/internal/metrics/plugins/podsbyPhase/log.go
@@ -1,0 +1,21 @@
+package podsbyPhase
+
+import (
+	"encoding/json"
+	"io"
+
+	metricsS "github.com/skpr/cluster-metrics/internal/metrics"
+)
+
+func (c Client) Log(writer io.Writer, metrics *metricsS.MetricSet) error {
+	encoder := json.NewEncoder(writer)
+	for _, metric := range metrics.Items {
+		metric.Name = metricName
+		metric.Type = typeGauge
+		err := encoder.Encode(&metric)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/metrics/plugins/podsbyPhase/log_test.go
+++ b/internal/metrics/plugins/podsbyPhase/log_test.go
@@ -1,0 +1,37 @@
+package podsbyPhase
+
+import (
+	"bytes"
+	metrics2 "github.com/skpr/cluster-metrics/internal/metrics"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestClient_Log(t *testing.T) {
+	metrics := metrics2.NewMetricSet()
+
+	metrics.IncrementSelect("ReplicaSet", "foo", "replicaset-foo-pending", map[string]string{"phase": "Pending"})
+	metrics.IncrementSelect("ReplicaSet", "foo", "replicaset-foo-pending", map[string]string{"phase": "Pending"})
+	metrics.IncrementSelect("ReplicaSet", "foo", "replicaset-foo-running", map[string]string{"phase": "Running"})
+	metrics.IncrementSelect("ReplicaSet", "bar", "replicaset-bar-pending", map[string]string{"phase": "Pending"})
+	metrics.IncrementSelect("ReplicaSet", "bar", "replicaset-bar-running", map[string]string{"phase": "Running"})
+	metrics.IncrementSelect("ReplicaSet", "bar", "replicaset-bar-running", map[string]string{"phase": "Running"})
+	metrics.IncrementSelect("ReplicaSet", "bar", "replicaset-bar-running", map[string]string{"phase": "Running"})
+	metrics.IncrementSelect("ReplicaSet", "bar", "replicaset-bar-running", map[string]string{"phase": "Running"})
+
+	var buf bytes.Buffer
+	var client Client
+	err := client.Log(&buf, metrics)
+	assert.NoError(t, err)
+	s := buf.String()
+
+	json1 := `{"name":"PodStatus","value":2,"type":"gauge","labels":{"kind":"ReplicaSet","namespace":"foo","phase":"Pending"}}`
+	json2 := `{"name":"PodStatus","value":1,"type":"gauge","labels":{"kind":"ReplicaSet","namespace":"foo","phase":"Running"}}`
+	json3 := `{"name":"PodStatus","value":1,"type":"gauge","labels":{"kind":"ReplicaSet","namespace":"bar","phase":"Pending"}}`
+	json4 := `{"name":"PodStatus","value":4,"type":"gauge","labels":{"kind":"ReplicaSet","namespace":"bar","phase":"Running"}}`
+
+	assert.Contains(t, s, json1)
+	assert.Contains(t, s, json2)
+	assert.Contains(t, s, json3)
+	assert.Contains(t, s, json4)
+}

--- a/internal/metrics/plugins/podsbyPhase/types.go
+++ b/internal/metrics/plugins/podsbyPhase/types.go
@@ -1,0 +1,21 @@
+package podsbyPhase
+
+import (
+	"github.com/skpr/cluster-metrics/internal/metrics/plugins"
+)
+
+const (
+	dimensionKind        = "kind"
+	dimensionEnvironment = "environment"
+	dimensionNamespace   = "namespace"
+	dimensionPhase       = "phase"
+	dimensionProject     = "project"
+	dimensionCluster     = "cluster"
+	metricTotal          = "total"
+	typeGauge            = "gauge"
+	metricName           = "PodStatus"
+)
+
+type Client struct {
+	plugins.ClusterMetricsPluginInterface
+}


### PR DESCRIPTION
The goal is to design an interface that could be reused for individual plugins for metrics to expand on the available metrics which this produces. This is not intended to be merged immediately but as to indicate if this is the most suitable place and/or direction.

**Requirements**

* Existing tests are modified to support any new/changed function calls and still pass.
* Interface signatures are suitable enough to use generically if another plugin was to be added.
* A clear example of a "plugin" is provided, that being the plugin which was originally supported.
* The overall design meets code quality standards and is on a path leading to support for additional metric plugins.
* Feedback is sought to either ensure this is an acceptable piece of work once complete, or if a new repository is better suited for this.

**Notes**

Not really important at this point, but things to keep in mind.

* The `Collect` signature needs to contain a clientset, I'm thinking the best way around this would be to embed fields into the plugins client.
* The `Logs` function could now be moved out of the interface however it was done to ensure initial compatibility with the proposed changes.