### PR TITLE
Update GoReleaser configuration

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,10 +11,7 @@ archives:
         {{- .Tag }}_
         {{- if eq .Os "darwin" }}macOS
         {{- else if eq .Os "linux"}}linux{{ end }}_
-        {{- if eq .Arch "amd64" }}x86_64
-        {{- else if eq .Arch "386" }}i386
-        {{- else }}{{ .Arch }}{{ end }}
-        {{- if .Arm }}v{{ .Arm }}{{ end -}}
+        {{- if eq .Arch "amd64" }}amd64{{ end }}
 dockers:
   - image_templates:
       - "skpr/cluster-metrics:latest"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,9 +4,7 @@ builds:
     goos: [ linux, darwin ]
     goarch: [ amd64 ]
 archives:
-  - replacements:
-      darwin: macOS
-    format: binary
+    - format: binary
 dockers:
   - image_templates:
       - "skpr/cluster-metrics:latest"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,6 +5,16 @@ builds:
     goarch: [ amd64 ]
 archives:
     - format: binary
+    - id: assets
+      name_template: >-
+        {{- .ProjectName }}_
+        {{- .Tag }}_
+        {{- if eq .Os "darwin" }}macOS
+        {{- else if eq .Os "linux"}}linux{{ end }}_
+        {{- if eq .Arch "amd64" }}x86_64
+        {{- else if eq .Arch "386" }}i386
+        {{- else }}{{ .Arch }}{{ end }}
+        {{- if .Arm }}v{{ .Arm }}{{ end -}}
 dockers:
   - image_templates:
       - "skpr/cluster-metrics:latest"


### PR DESCRIPTION
GoReleaser configuration has to be updated given the last release was such a while ago.

The output from the proposed change can be found below.

```
[fubarhouse@fubarhouse cluster-metrics]$ goreleaser --skip=validate --skip=publish --clean
  • starting release...
  • loading                                          path=.goreleaser.yml
  • skipping announce, publish and validate...
  • loading environment variables
  • getting and validating git state
    • git state                                      commit=4d794d834db4dc51864abeea396b0dad55f1d90e branch=goreleaser-fixes current_tag=v0.0.11 previous_tag=v0.0.10 dirty=true
    • pipe skipped                                   reason=validation is disabled
  • parsing tag
  • setting defaults
  • checking distribution directory
    • cleaning dist
  • loading go mod information
  • build prerequisites
  • writing effective config file
    • writing                                        config=dist/config.yaml
  • building binaries
    • building                                       binary=dist/cluster-metrics_darwin_amd64_v1/cluster-metrics
    • building                                       binary=dist/cluster-metrics_linux_amd64_v1/cluster-metrics
    • took: 1s
  • generating changelog
    • writing                                        changelog=dist/CHANGELOG.md
  • archives
    • skip archiving                                 binary=cluster-metrics name=cluster-metrics_0.0.11_linux_amd64
    • skip archiving                                 binary=cluster-metrics name=cluster-metrics_0.0.11_darwin_amd64
    • creating                                       archive=dist/cluster-metrics_v0.0.11_macOS_x86_64.tar.gz
    • creating                                       archive=dist/cluster-metrics_v0.0.11_linux_x86_64.tar.gz
    • took: 2s
  • calculating checksums
  • docker images
    • building docker image                          image=skpr/cluster-metrics:latest
    • took: 5s
  • storing release metadata
    • writing                                        file=dist/artifacts.json
    • writing                                        file=dist/metadata.json
  • release succeeded after 8s
  • thanks for using goreleaser!
```